### PR TITLE
Fix support image builds

### DIFF
--- a/.github/workflows/support-images.yaml
+++ b/.github/workflows/support-images.yaml
@@ -3,7 +3,7 @@ name: build support images
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "13 * * * 0"
+    - cron: "13 4 * * 0"
 
 jobs:
   build_support_images:

--- a/.github/workflows/support-images.yaml
+++ b/.github/workflows/support-images.yaml
@@ -21,9 +21,9 @@ jobs:
         run: |
           docker build --tag ghcr.io/jsandas/centos-saltstack:7 -f dockerfiles/Dockerfile-centos7 .
 
-      - name: Build opensuseleap15.3-minion image
+      - name: Build opensuseleap15.4-minion image
         run: |
-          docker build --tag ghcr.io/jsandas/opensuseleap-saltstack:15.3 -f dockerfiles/Dockerfile-opensuseleap15.3 .
+          docker build --tag ghcr.io/jsandas/opensuseleap-saltstack:15.4 -f dockerfiles/Dockerfile-opensuseleap15.4 .
 
       - name: Build ubuntu2004-minion image
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 FROM python:3-alpine
 
-ENV MAKEFLAGS="-j$(nproc)"
-
 WORKDIR /opt/saltui
 
 COPY ./ /opt/saltui
 
 # build dependencies
 RUN apk add --no-cache --virtual .build-deps build-base libffi-dev postgresql-dev \
-    && pip install --no-cache-dir -r requirements.txt \
+    && MAKEFLAGS="-j$(nproc)"; pip install --no-cache-dir -r requirements.txt \
     && apk del .build-deps
 
 # install required packages/scripts

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ build-dev:
 build-dev-nocache:
 	docker-compose -f docker-compose_dev.yaml build --no-cache
 
+build-dependencies:
+	docker build --tag ghcr.io/jsandas/alpine-saltstack:3.12 -f dockerfiles/Dockerfile-alpine3.12 .
+	docker build --tag ghcr.io/jsandas/centos-saltstack:7 -f dockerfiles/Dockerfile-centos7 .
+	docker build --tag ghcr.io/jsandas/opensuseleap-saltstack:15.4 -f dockerfiles/Dockerfile-opensuseleap15.4 .
+	docker build --tag ghcr.io/jsandas/ubuntu-saltstack:20.04 -f dockerfiles/Dockerfile-ubuntu2004 .
+
 clean: stop-dev
 	rm -rf data_files/data
 

--- a/docker-compose_dev.yaml
+++ b/docker-compose_dev.yaml
@@ -104,8 +104,8 @@ services:
       - salt-master
 
   opensuseleap15.3-minion:
-    image: ghcr.io/jsandas/opensuseleap-saltstack:15.3
-    container_name: opensuseleap15.3-minion
-    hostname: opensuseleap15.3-minion
+    image: ghcr.io/jsandas/opensuseleap-saltstack:15.4
+    container_name: opensuseleap15.4-minion
+    hostname: opensuseleap15.4-minion
     depends_on:
       - salt-master

--- a/dockerfiles/Dockerfile-opensuseleap15.4
+++ b/dockerfiles/Dockerfile-opensuseleap15.4
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.3
+FROM opensuse/leap:15.4
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.


### PR DESCRIPTION
The opensuse image build fails because it is unable to validation the repo url